### PR TITLE
fixed bug] BUG说明：Connection类继承了Redis类，重了open方法，open方法和Redis类中的open方法参数不一致，error_reporting开启严格模式以后，会产生一条警告

### DIFF
--- a/Connection.php
+++ b/Connection.php
@@ -77,6 +77,7 @@ class Connection extends Redis implements Configurable
      * Establishes a DB connection.
      * It does nothing if a DB connection has already been established.
      * @throws RedisException if connection fails
+     * @example 问题详细描述 https://bugs.php.net/bug.php?id=46851
      * @see connect()
      * @param string    $host
      * @param int       $port

--- a/Connection.php
+++ b/Connection.php
@@ -77,13 +77,28 @@ class Connection extends Redis implements Configurable
      * Establishes a DB connection.
      * It does nothing if a DB connection has already been established.
      * @throws RedisException if connection fails
+     * @see connect()
+     * @param string    $host
+     * @param int       $port
+     * @param float     $timeout
+     * @param int       $retry_interval
+     * @return bool
      */
-    public function open()
+    public function open( $host = null, $port = null, $timeout = null, $retry_interval = 0 )
     {
         if ($this->unixSocket !== null) {
             $isConnected = $this->connect($this->unixSocket);
         } else {
-            $isConnected = $this->connect($this->hostname, $this->port, $this->connectionTimeout);
+            if(is_null($host)){
+                $host = $this->hostname;
+            }
+            if(is_null($port)){
+                $port = $this->port;
+            }
+            if(is_null($timeout)){
+                $timeout = $this->connectionTimeout;
+            }
+            $isConnected = $this->connect($host, $port, $timeout, null, $retry_interval);
         }
 
         if ($isConnected === false) {

--- a/Connection.php
+++ b/Connection.php
@@ -77,7 +77,7 @@ class Connection extends Redis implements Configurable
      * Establishes a DB connection.
      * It does nothing if a DB connection has already been established.
      * @throws RedisException if connection fails
-     * @example 问题详细描述 https://bugs.php.net/bug.php?id=46851
+     * @example 问题详细描述 https://bugs.php.net/bug.php?id=46851  php_redis.so 版本为4.0.2时会出现一条警告
      * @see connect()
      * @param string    $host
      * @param int       $port


### PR DESCRIPTION
Connection类继承了Redis类，重了open方法，open方法和Redis类中的open方法参数不一致，error_reporting开启严格模式以后，会产生一条警告：Declaration of dcb9\redis\Connection::open() should be compatible with Redis::open($host, $port = NULL, $timeout = NULL, $retry_interval = NULL)。
问题详细描述：https://bugs.php.net/bug.php?id=46851